### PR TITLE
Support for setting shared lib path & update alternatives.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Attributes
 * `node['oracle-instantclient']['public-url']` - The URL of where you are hosting the RPMs
 * `node['oracle-instantclient']['sqlplus-rpm']` - The filename of the SQL*Plus RPM
 * `node['oracle-instantclient']['basic-rpm']` - The filename of the basic Instant Client RPM
+* `node['oracle-instantclient']['version'] - The version of Oracle e.g. "12.1" - as used by rpm 
+   installation prefix in "/usr/lib/oracle/<version>"
 
 Recipes
 =======
@@ -41,11 +43,6 @@ sqlplus
 -------
 
 The sqlplus recipe will install both the Instant Client and SQL*Plus.
-
-Bugs
-====
-
-`sqlplus` (or `sqlplus64` if you're on a 64-bit platform) doesn't work out of the box without setting `LD_LIBRARY_PATH`.
 
 Author and License
 ==================

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,4 +21,6 @@ default['oracle-instantclient']['public-url'] = nil
 default['oracle-instantclient']['sqlplus-rpm'] = node['machine'] == 'x86_64' ? 'oracle-instantclient12.1-sqlplus-12.1.0.1.0-1.x86_64.rpm' : 'oracle-instantclient12.1-basic-12.1.0.1.0-1.i386.rpm'
 default['oracle-instantclient']['sdk-rpm'] = node['machine'] == 'x86_64' ? 'oracle-instantclient12.1-devel-12.1.0.1.0-1.x86_64.rpm' : 'oracle-instantclient12.1-devel-12.1.0.1.0-1.i386.rpm'
 default['oracle-instantclient']['basic-rpm'] = node['machine'] == 'x86_64' ? 'oracle-instantclient12.1-basic-12.1.0.1.0-1.x86_64.rpm' : 'oracle-instantclient12.1-basic-12.1.0.1.0-1.i386.rpm'
-default['oracle-instantclient']['version'] = '12.1'
+# If this automatic attempt to deduce major version fails
+# then please set manually
+default['oracle-instantclient']['version'] = default['oracle-instantclient']['sqlplus-rpm'].split('-')[1].sub(/instantclient/, '')

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,3 +20,4 @@
 default['oracle-instantclient']['public-url'] = nil
 default['oracle-instantclient']['sqlplus-rpm'] = node['machine'] == 'x86_64' ? 'oracle-instantclient12.1-sqlplus-12.1.0.1.0-1.x86_64.rpm' : 'oracle-instantclient12.1-basic-12.1.0.1.0-1.i386.rpm'
 default['oracle-instantclient']['basic-rpm'] = node['machine'] == 'x86_64' ? 'oracle-instantclient12.1-basic-12.1.0.1.0-1.x86_64.rpm' : 'oracle-instantclient12.1-basic-12.1.0.1.0-1.i386.rpm'
+default['oracle-instantclient']['version'] = '12.1'

--- a/files/default/profile.d/oracle-instantclient.sh
+++ b/files/default/profile.d/oracle-instantclient.sh
@@ -1,0 +1,2 @@
+LD_LIBRARY_PATH="$LD_LIBARY_PATH:/usr/lib/oracle/12.1/client64/lib"
+export LD_LIBRARY_PATH

--- a/files/default/profile.d/oracle-instantclient.sh
+++ b/files/default/profile.d/oracle-instantclient.sh
@@ -1,2 +1,0 @@
-LD_LIBRARY_PATH="$LD_LIBARY_PATH:/usr/lib/oracle/12.1/client64/lib"
-export LD_LIBRARY_PATH

--- a/libraries/utils.rb
+++ b/libraries/utils.rb
@@ -2,19 +2,24 @@ require 'chef/mixin/shell_out'
 include Chef::Mixin::ShellOut
 
 module OracleUtils
-    def install_alternatives
-        bin_path = "/usr/bin/sqlplus"
-        client_arch = node[:kernel][:machine] == "x86_64" ? "client64" : "client"
-        alt_path = "/usr/lib/oracle/#{node["oracle-instantclient"]["version"]}/#{client_arch}/bin/sqlplus"
-        install_cmd = "update-alternatives --install #{bin_path} sqlplus #{alt_path} 1000"
-        Chef::Log.debug install_cmd
-        alternative_exists = shell_out("update-alternatives --display sqlplus | grep #{alt_path}").exitstatus == 0
-        unless alternative_exists
-            Chef::Log.debug "Adding alternative for sqlplus"
-            install_result = shell_out(install_cmd)
-            unless install_result.exitstatus == 0
-                Chef::Application.fatal!("Failed to set sqlplus alternative", 1)
-            end
-        end
+  def initialize(node)
+    @node = node.to_hash
+  end
+
+  def install_alternatives
+    bin_path = "/usr/bin/sqlplus"
+    client_arch = @node['kernel']['machine'] == "x86_64" ? "client64" : "client"
+    Chef::Log.debug "OracleUtils: node[oracle-instantclient][version] is #{@node["oracle-instantclient"]["version"]}"
+    alt_path = "/usr/lib/oracle/#{@node["oracle-instantclient"]["version"]}/#{client_arch}/bin/sqlplus"
+    install_cmd = "update-alternatives --install #{bin_path} sqlplus #{alt_path} 1000"
+    Chef::Log.debug install_cmd
+    alternative_exists = shell_out("update-alternatives --display sqlplus | grep #{alt_path}").exitstatus == 0
+    unless alternative_exists
+      Chef::Log.debug "OracleUtils: Adding alternative for sqlplus"
+      install_result = shell_out(install_cmd)
+      unless install_result.exitstatus == 0
+        Chef::Application.fatal!("OracleUtils: Failed to set sqlplus alternative", 1)
+      end
     end
+  end
 end

--- a/libraries/utils.rb
+++ b/libraries/utils.rb
@@ -1,0 +1,20 @@
+require 'chef/mixin/shell_out'
+include Chef::Mixin::ShellOut
+
+module OracleUtils
+    def install_alternatives
+        bin_path = "/usr/bin/sqlplus"
+        client_arch = node[:kernel][:machine] == "x86_64" ? "client64" : "client"
+        alt_path = "/usr/lib/oracle/#{node["oracle-instantclient"]["version"]}/#{client_arch}/bin/sqlplus"
+        install_cmd = "update-alternatives --install #{bin_path} sqlplus #{alt_path} 1000"
+        Chef::Log.debug install_cmd
+        alternative_exists = shell_out("update-alternatives --display sqlplus | grep #{alt_path}").exitstatus == 0
+        unless alternative_exists
+            Chef::Log.debug "Adding alternative for sqlplus"
+            install_result = shell_out(install_cmd)
+            unless install_result.exitstatus == 0
+                Chef::Application.fatal!("Failed to set sqlplus alternative", 1)
+            end
+        end
+    end
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,17 +17,6 @@
 # limitations under the License.
 #
 
-client_arch = node[:kernel][:machine] == "x86_64" ? "client64" : "client"
-template '/etc/ld.so.conf.d/oracle-instantclient-86_64.conf' do
-    source 'ld.so.conf.d/oracle-instantclient-86_64.conf.erb'
-    owner 'root'
-    group 'root'
-    mode '0644'
-    variables ({
-        :version => node['oracle-instantclient']['version'],
-        :client_arch => client_arch
-    })
-end
 
 remote_file File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['basic-rpm']) do
   source node['oracle-instantclient']['public-url'] + node['oracle-instantclient']['basic-rpm']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,18 @@
 # limitations under the License.
 #
 
+client_arch = node[:kernel][:machine] == "x86_64" ? "client64" : "client"
+template '/etc/ld.so.conf.d/oracle-instantclient-86_64.conf' do
+    source 'ld.so.conf.d/oracle-instantclient-86_64.conf.erb'
+    owner 'root'
+    group 'root'
+    mode '0644'
+    variables ({
+        :version => node['oracle-instantclient']['version'],
+        :client_arch => client_arch
+    })
+end
+
 remote_file File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['basic-rpm']) do
   source node['oracle-instantclient']['public-url'] + node['oracle-instantclient']['basic-rpm']
   action :create
@@ -27,9 +39,3 @@ yum_package 'oracle-instantclient12.1-basic' do
   action :install
 end
 
-cookbook_file '/etc/profile.d/oracle-instantclient.sh' do
-    source 'profile.d/oracle-instantclient.sh'
-    owner 'root'
-    group 'root'
-    mode '0644'
-end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,3 +26,10 @@ yum_package 'oracle-instantclient12.1-basic' do
   source File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['basic-rpm'])
   action :install
 end
+
+cookbook_file '/etc/profile.d/oracle-instantclient.sh' do
+    source 'profile.d/oracle-instantclient.sh'
+    owner 'root'
+    group 'root'
+    mode '0644'
+end

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -1,0 +1,24 @@
+# Cookbook Name:: oracle-instantclient
+# Recipe:: default
+#
+# Copyright (C) 2013 Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe "oracle-instantclient::sdk"
+
+gem_package "ruby-oci8" do
+  action :install
+end
+

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -18,6 +18,10 @@
 
 include_recipe "oracle-instantclient::sdk"
 
+# Explicitly set LD_LIBRARY_PATH otherwise the gem won't build
+client_arch = node['kernel']['machine'] == "x86_64" ? "client64" : "client"
+ENV['LD_LIBRARY_PATH'] = "/usr/lib/oracle/#{node['oracle-instantclient']['version']}/#{client_arch}/lib"
+
 gem_package "ruby-oci8" do
   action :install
 end

--- a/recipes/sdk.rb
+++ b/recipes/sdk.rb
@@ -1,0 +1,30 @@
+#
+# Cookbook Name:: oracle-instantclient
+# Recipe:: default
+#
+# Copyright (C) 2013 Opscode, Inc.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#    http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe "oracle-instantclient"
+
+remote_file File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['sdk-rpm']) do
+  source node['oracle-instantclient']['public-url'] + node['oracle-instantclient']['sdk-rpm']
+  action :create
+end
+
+yum_package 'oracle-instantclient12.1-devel' do
+  source File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['sdk-rpm'])
+  action :install
+end

--- a/recipes/sqlplus.rb
+++ b/recipes/sqlplus.rb
@@ -33,4 +33,22 @@ yum_package 'oracle-instantclient12.1-sqlplus' do
   action :install
 end
 
+execute "ldconfig" do
+  command "ldconfig"
+  action :nothing
+end
+
+client_arch = node['kernel']['machine'] == "x86_64" ? "client64" : "client"
+template '/etc/ld.so.conf.d/oracle-instantclient-86_64.conf' do
+  source 'ld.so.conf.d/oracle-instantclient-86_64.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  variables ({
+      :version => node['oracle-instantclient']['version'],
+      :client_arch => client_arch
+  })
+  notifies :run, "execute[ldconfig]"
+end
+
 install_alternatives

--- a/recipes/sqlplus.rb
+++ b/recipes/sqlplus.rb
@@ -17,6 +17,10 @@
 # limitations under the License.
 #
 
+class Chef::Recipe
+    include OracleUtils
+end
+
 include_recipe "oracle-instantclient"
 
 remote_file File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['sqlplus-rpm']) do
@@ -28,3 +32,5 @@ yum_package 'oracle-instantclient12.1-sqlplus' do
   source File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['sqlplus-rpm'])
   action :install
 end
+
+install_alternatives

--- a/templates/default/ld.so.conf.d/oracle-instantclient-86_64.conf.erb
+++ b/templates/default/ld.so.conf.d/oracle-instantclient-86_64.conf.erb
@@ -1,0 +1,1 @@
+/usr/lib/oracle/<%= @version %>/<%= @client_arch %>/lib


### PR DESCRIPTION
Hello,

In order to have sqlplus work out of the box I have made the following changes and wanted to submit it for review in the event it is something you can merge (I am totally open to suggestions with regards to better ways to do this) - 
- /etc/ld.so.conf.d/oracle-instantclient-x86_64.conf file for setting the shared lib path
- New cookbook library to set up the "sqlplus" alternative so that you can always call sqlplus the usual way e.g. "sqlplus" instead of "sqlplus64"

To support the above I needed to make it easier to determine the path to the "lib" dir. So I created a new attribute "node['oracle-instantclient']['version'] which takes the major.minor version format e.g. "12.1". This could potentially be automated but parsing the version string and/or RPM name is fragile and it seemed better to just have the user specify the version. This version string is then used to construct the path to the instant client "lib" dir.

Also I chose to make a cookbook library to do the update-alternatives dirty work so as to keep the recipes clean. I also did not update the version in metadata.rb - I'll leave that to you.

UPDATE: Also added support to install the Ruby oci8 gem so that Oracle queries can be run. This required
- Add "devel" RPMs to attributes
- Create "sdk" recipe to install the devel RPM
- Create "ruby" recipe which depends on the "sdk" recipe; this will install the oci8 gem

Users can then call "oracle_instantclient::ruby" if they want to use Oracle from recipes, providers, etc.

Regards,

Fred.
