### PR TITLE
Update alternatives only after package installation.

### DIFF
--- a/libraries/utils.rb
+++ b/libraries/utils.rb
@@ -23,13 +23,6 @@ include Chef::Mixin::ShellOut
 
 # Helper methods for managing sqlplus
 module OracleUtils
-  def initialize(operation, run_context)
-    # When using the metaprogramming magic we receive two arguments
-    # instead of one for the constructor. Ignoring the first one and 
-    # just extracting the node.
-    @n = run_context.node.to_hash
-  end
-
   def install_alternatives
     bin_path = '/usr/bin/sqlplus'
     client_arch = @n['kernel']['machine'] == 'x86_64' ? 'client64' : 'client'

--- a/libraries/utils.rb
+++ b/libraries/utils.rb
@@ -23,8 +23,11 @@ include Chef::Mixin::ShellOut
 
 # Helper methods for managing sqlplus
 module OracleUtils
-  def initialize(node)
-    @node = node.to_hash
+  def initialize(operation, run_context)
+    # When using the metaprogramming magic we receive two arguments
+    # instead of one for the constructor. Ignoring the first one and 
+    # just extracting the node.
+    @node = run_context.node.to_hash
   end
 
   def install_alternatives

--- a/recipes/sqlplus.rb
+++ b/recipes/sqlplus.rb
@@ -52,6 +52,7 @@ end
 ruby_block 'update-alternatives' do
   block do
     Chef::Resource::RubyBlock.send(:include, Chef::Recipe::OracleUtils)
+    @n = node.to_hash
     install_alternatives
   end
 end

--- a/recipes/sqlplus.rb
+++ b/recipes/sqlplus.rb
@@ -18,10 +18,6 @@
 # limitations under the License.
 #
 
-class Chef::Recipe
-  include OracleUtils
-end
-
 include_recipe 'oracle-instantclient'
 
 remote_file File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['sqlplus-rpm']) do
@@ -32,6 +28,7 @@ end
 yum_package 'oracle-instantclient12.1-sqlplus' do
   source File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['sqlplus-rpm'])
   action :install
+  notifies :run, "ruby_block[update-alternatives]", :immediately
 end
 
 execute 'ldconfig' do
@@ -52,4 +49,9 @@ template '/etc/ld.so.conf.d/oracle-instantclient-86_64.conf' do
   notifies :run, 'execute[ldconfig]'
 end
 
-install_alternatives
+ruby_block 'update-alternatives' do
+  block do
+    Chef::Resource::RubyBlock.send(:include, Chef::Recipe::OracleUtils)
+    install_alternatives
+  end
+end


### PR DESCRIPTION
Hello Julian,

I noticed, that on a clean box, the sqlplus recipe was failing by trying to set the alternatives prior to sqlplus package installation. What _I think_ was happening is that it would run the Ruby library code at recipe compile time instead of recipe execution time. This meant that the binaries update-alternatives uses are not present.

This PR is an attempt at fixing this situation by
- Removing the Ruby library 
- Create a ruby_block containing the update alternatives code (that used to be in the library)
- Call this ruby block once the sqlplus RPM has been installed

I modelled this approach on what the Java cookbook does. Perhaps a cleaner way is to figure out how a ruby_block can call a Chef cookbook library. That way the recipe code can be kept tidier however it is still pretty short so I figure it was OK in this instance.

Thanks,

Fred.
