### PR TITLE
Add Ubuntu 14.04 support.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,6 +9,7 @@ platforms:
   - name: centos-6.5
   - name: centos-6.5-i386
   - name: centos-5.10
+  - name: ubuntu-14.04
     run_list:
       - recipe[yum]
     attributes:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: test default lint
+
+default: test
+
+test:
+	ruby -e 'ARGV.each {|file| require file}' ./test/*/*.rb
+
+lint:
+	rubocop libraries/ recipes/ test/ attributes/

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,9 +18,16 @@
 # limitations under the License.
 
 default['oracle-instantclient']['public-url'] = nil
+
 default['oracle-instantclient']['sqlplus-rpm'] = node['kernel']['machine'] == 'x86_64' ? 'oracle-instantclient12.1-sqlplus-12.1.0.1.0-1.x86_64.rpm' : 'oracle-instantclient12.1-sqlplus-12.1.0.1.0-1.i386.rpm'
+default['oracle-instantclient']['sqlplus-sha256'] = ''
+
 default['oracle-instantclient']['sdk-rpm'] = node['kernel']['machine'] == 'x86_64' ? 'oracle-instantclient12.1-devel-12.1.0.1.0-1.x86_64.rpm' : 'oracle-instantclient12.1-devel-12.1.0.1.0-1.i386.rpm'
+default['oracle-instantclient']['sdk-sha256'] = ''
+
 default['oracle-instantclient']['basic-rpm'] = node['kernel']['machine'] == 'x86_64' ? 'oracle-instantclient12.1-basic-12.1.0.1.0-1.x86_64.rpm' : 'oracle-instantclient12.1-basic-12.1.0.1.0-1.i386.rpm'
+default['oracle-instantclient']['basic-sha256'] = ''
+
 # If this automatic attempt to deduce major version fails
 # then please set manually
 default['oracle-instantclient']['version'] = default['oracle-instantclient']['sqlplus-rpm'].split('-')[1].sub(/instantclient/, '')

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,3 +31,4 @@ default['oracle-instantclient']['basic-sha256'] = ''
 # If this automatic attempt to deduce major version fails
 # then please set manually
 default['oracle-instantclient']['version'] = default['oracle-instantclient']['sqlplus-rpm'].split('-')[1].sub(/instantclient/, '')
+default['oracle-instantclient']['debian_packages'] = %w(alien libaio1)

--- a/libraries/mixin_alien_converter.rb
+++ b/libraries/mixin_alien_converter.rb
@@ -48,7 +48,6 @@ class Chef
       def alien_package_debian_filename
         name = String.new alien_source_filename
         version = String.new alien_package_version
-        Chef::Log.info("Version: #{version}")
         name.gsub("-#{version}.x86_64.rpm", "_#{version}_amd64.deb")
       end
 

--- a/libraries/mixin_alien_converter.rb
+++ b/libraries/mixin_alien_converter.rb
@@ -34,7 +34,7 @@ class Chef
       end
 
       def alien_command
-        "alien #{alien_source_filename}"
+        "alien -k #{alien_source_filename}"
       end
 
       def alien_install_command

--- a/libraries/mixin_alien_converter.rb
+++ b/libraries/mixin_alien_converter.rb
@@ -20,46 +20,46 @@ class Chef
   module Mixin
     # Base functionality module for generating the alien shell command.
     module AlienConverter
-      def log_convert
-        if !::File.exists? package_debian_source
-          Chef::Log.info("Alien converting package to - #{package_debian_source}.")
-          convert
+      def alien_log_convert
+        if !::File.exists? alien_package_debian_source
+          Chef::Log.info("Alien converting package to - #{alien_package_debian_source}.")
+          alien_convert
         else
-          Chef::Log.info("Converted package present - #{package_debian_source}.")
+          Chef::Log.info("Converted package present - #{alien_package_debian_source}.")
         end
       end
 
-      def convert
-        shell_out!(*command)
+      def alien_convert
+        shell_out!(*alien_command)
       end
 
-      def command
-        "alien #{package_name}"
+      def alien_command
+        "alien #{alien_package_name}"
       end
 
-      def package_debian_source
-        File.join(package_directory, package_debian_name)
+      def alien_package_debian_source
+        File.join(alien_package_directory, alien_package_debian_name)
       end
 
-      def package_debian_name
-        name = String.new package_name
-        version = String.new package_version
+      def alien_package_debian_name
+        name = String.new alien_package_name
+        version = String.new alien_package_version
         name.gsub("-#{version}.x86_64.rpm", "_#{version}_amd64.deb")
       end
 
-      def package_name
-        File.basename(package_source_path)
+      def alien_package_name
+        File.basename(alien_package_source_path)
       end
 
-      def package_version
-        package_source_path.match(/(\d+\.)+(\d+-\d*)*/)[0]
+      def alien_package_version
+        alien_package_source_path.match(/(\d+\.)+(\d+-\d*)*/)[0]
       end
 
-      def package_directory
-        File.dirname(package_source_path)
+      def alien_package_directory
+        File.dirname(alien_package_source_path)
       end
 
-      def package_source_path
+      def alien_package_source_path
         new_resource.source
       end
     end

--- a/libraries/mixin_alien_converter.rb
+++ b/libraries/mixin_alien_converter.rb
@@ -34,7 +34,7 @@ class Chef
       end
 
       def alien_command
-        "alien #{alien_source_filename}"
+        "cd #{alien_package_directory} && alien #{alien_source_filename}"
       end
 
       def alien_install_command
@@ -57,7 +57,7 @@ class Chef
       end
 
       def alien_package_version
-        alien_package_source_path.match(/\w-(\d+\.)+(\d+-\d*)*/)[0].gsub(/^\w-/, '')
+        alien_package_source_path.match(/\w(-|_)(\d+\.)+(\d+-\d*)*/)[0].gsub(/^\w-/, '')
       end
 
       def alien_package_directory
@@ -65,7 +65,7 @@ class Chef
       end
 
       def alien_package_source_path
-        @new_resource.source
+        new_resource.source
       end
     end
   end

--- a/libraries/mixin_alien_converter.rb
+++ b/libraries/mixin_alien_converter.rb
@@ -1,0 +1,67 @@
+# Cookbook Name:: oracle-instantclient
+# Mixin:: alien_converter
+# Author:: David Kinzer <dtkinzer@gmail.com>
+#
+# Copyright (C) 2014 David Kinzer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class Chef
+  module Mixin
+    # Base functionality module for generating the alien shell command.
+    module AlienConverter
+      def log_convert
+        if !::File.exists? package_debian_source
+          Chef::Log.info("Alien converting package to - #{package_debian_source}.")
+          convert
+        else
+          Chef::Log.info("Converted package present - #{package_debian_source}.")
+        end
+      end
+
+      def convert
+        shell_out!(*command)
+      end
+
+      def command
+        "alien #{package_name}"
+      end
+
+      def package_debian_source
+        File.join(package_directory, package_debian_name)
+      end
+
+      def package_debian_name
+        name = String.new package_name
+        version = String.new package_version
+        name.gsub("-#{version}.x86_64.rpm", "_#{version}_amd64.deb")
+      end
+
+      def package_name
+        File.basename(package_source_path)
+      end
+
+      def package_version
+        package_source_path.match(/(\d+\.)+(\d+-\d*)*/)[0]
+      end
+
+      def package_directory
+        File.dirname(package_source_path)
+      end
+
+      def package_source_path
+        new_resource.source
+      end
+    end
+  end
+end

--- a/libraries/mixin_alien_converter.rb
+++ b/libraries/mixin_alien_converter.rb
@@ -34,7 +34,7 @@ class Chef
       end
 
       def alien_command
-        "cd #{alien_package_directory} && alien #{alien_source_filename}"
+        "alien #{alien_source_filename}"
       end
 
       def alien_install_command
@@ -57,7 +57,7 @@ class Chef
       end
 
       def alien_package_version
-        alien_package_source_path.match(/\w(-|_)(\d+\.)+(\d+-\d*)*/)[0].gsub(/^\w-/, '')
+        alien_package_source_path.match(/\w(-|_)(\d+\.)+(\d+-\d*)*/)[0].gsub(/^\w(-|_)/, '')
       end
 
       def alien_package_directory
@@ -65,7 +65,7 @@ class Chef
       end
 
       def alien_package_source_path
-        new_resource.source
+        @new_resource.source
       end
     end
   end

--- a/libraries/mixin_alien_converter.rb
+++ b/libraries/mixin_alien_converter.rb
@@ -34,25 +34,30 @@ class Chef
       end
 
       def alien_command
-        "alien #{alien_package_name}"
+        "alien #{alien_source_filename}"
+      end
+
+      def alien_install_command
+        shell_out!("dpkg -i #{alien_package_debian_source}")
       end
 
       def alien_package_debian_source
-        File.join(alien_package_directory, alien_package_debian_name)
+        File.join(alien_package_directory, alien_package_debian_filename)
       end
 
-      def alien_package_debian_name
-        name = String.new alien_package_name
+      def alien_package_debian_filename
+        name = String.new alien_source_filename
         version = String.new alien_package_version
+        Chef::Log.info("Version: #{version}")
         name.gsub("-#{version}.x86_64.rpm", "_#{version}_amd64.deb")
       end
 
-      def alien_package_name
+      def alien_source_filename
         File.basename(alien_package_source_path)
       end
 
       def alien_package_version
-        alien_package_source_path.match(/(\d+\.)+(\d+-\d*)*/)[0]
+        alien_package_source_path.match(/\w-(\d+\.)+(\d+-\d*)*/)[0].gsub(/^\w-/, '')
       end
 
       def alien_package_directory
@@ -60,7 +65,7 @@ class Chef
       end
 
       def alien_package_source_path
-        new_resource.source
+        @new_resource.source
       end
     end
   end

--- a/libraries/provider_alien_convert.rb
+++ b/libraries/provider_alien_convert.rb
@@ -28,9 +28,9 @@ class Chef
       def initialize(new_resource, run_context)
         super
         Chef::Log.info("Run Context #{run_context}")
-        new_resource.cwd alien_package_directory
-        new_resource.command  alien_command
-        new_resource.creates alien_package_debian_source
+        @new_resource.cwd alien_package_directory
+        @new_resource.command  alien_command
+        @new_resource.creates alien_package_debian_source
       end
 
       def action_convert

--- a/libraries/provider_alien_convert.rb
+++ b/libraries/provider_alien_convert.rb
@@ -44,8 +44,8 @@ class Chef
         opts = {}
         opts[:timeout] = @new_resource.timeout || 3600
         opts[:returns] = @new_resource.returns
-        opts[:environment] = @new_resource
-        opts[:user] = @new_resource
+        opts[:environment] = @new_resource.environment
+        opts[:user] = @new_resource.user
         opts[:group] = @new_resource.group
         opts[:cwd] = @new_resource.cwd
         opts[:umask] = @new_resource.umask

--- a/libraries/provider_alien_convert.rb
+++ b/libraries/provider_alien_convert.rb
@@ -33,9 +33,13 @@ class Chef
       end
 
       def action_convert
+        if ::File.exists? @new_resource.creates
+          Chef::Log.info("Converted Package #{alien_package_debian_filename} exists - nothing to do")
+          return false
+        end
         converge_by("alien_convert #{@new_resource.name}") do
           shell_out!(@new_resource.command, options)
-          Chef::Log.info('Alien conversion successful.')
+          Chef::Log.info("Alien conversion successful: #{alien_package_debian_filename}.")
         end
       end
 

--- a/libraries/provider_alien_convert.rb
+++ b/libraries/provider_alien_convert.rb
@@ -28,9 +28,9 @@ class Chef
       def initialize(new_resource, run_context)
         super
         Chef::Log.info("Run Context #{run_context}")
-        new_resource.cwd package_directory
-        new_resource.command  command
-        new_resource.creates package_debian_source
+        new_resource.cwd alien_package_directory
+        new_resource.command  alien_command
+        new_resource.creates alien_package_debian_source
       end
 
       def action_convert

--- a/libraries/provider_alien_convert.rb
+++ b/libraries/provider_alien_convert.rb
@@ -27,7 +27,6 @@ class Chef
 
       def initialize(new_resource, run_context)
         super
-        Chef::Log.info("Run Context #{run_context}")
         @new_resource.cwd alien_package_directory
         @new_resource.command  alien_command
         @new_resource.creates alien_package_debian_source

--- a/libraries/provider_alien_convert.rb
+++ b/libraries/provider_alien_convert.rb
@@ -1,0 +1,61 @@
+# Cookbook Name:: oracle-instantclient
+# Provider:: AlienConvert
+# Author:: David Kinzer <dtkinzer@gmail.com>
+#
+# Copyright (C) 2014 David Kinzer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'chef/provider/execute'
+require_relative 'mixin_alien_converter'
+
+class Chef
+  class Provider
+    # Provides the default functionality for the alien_convert resource.
+    class AlienConvert < Chef::Provider::Execute
+      include Chef::Mixin::AlienConverter
+
+      def initialize(new_resource, run_context)
+        super
+        Chef::Log.info("Run Context #{run_context}")
+        new_resource.cwd package_directory
+        new_resource.command  command
+        new_resource.creates package_debian_source
+      end
+
+      def action_convert
+        if sentinel_file_if_exists
+          Chef::Log.debug("#{@new_resource} sentinel file #{sentinel_file} exists - nothing to do")
+          return false
+        end
+
+        converge_by("alien_convert #{@new_resource.name}") do
+          shell_out!(@new_resource.command, options)
+          Chef::Log.info('Alien conversion successful.')
+        end
+      end
+
+      def options
+        opts = {}
+        opts[:timeout] = @new_resource.timeout || 3600
+        opts[:returns] = @new_resource.returns
+        opts[:environment] = @new_resource
+        opts[:user] = @new_resource
+        opts[:group] = @new_resource.group
+        opts[:cwd] = @new_resource.cwd
+        opts[:umask] = @new_resource.umask
+        opts.delete_if { |k, v| v.nil? }
+      end
+    end
+  end
+end

--- a/libraries/provider_alien_convert.rb
+++ b/libraries/provider_alien_convert.rb
@@ -34,11 +34,6 @@ class Chef
       end
 
       def action_convert
-        if sentinel_file_if_exists
-          Chef::Log.debug("#{@new_resource} sentinel file #{sentinel_file} exists - nothing to do")
-          return false
-        end
-
         converge_by("alien_convert #{@new_resource.name}") do
           shell_out!(@new_resource.command, options)
           Chef::Log.info('Alien conversion successful.')

--- a/libraries/provider_alien_dpkg.rb
+++ b/libraries/provider_alien_dpkg.rb
@@ -29,8 +29,8 @@ class Chef
       def initialize(new_resource, run_context)
         super
         Chef::Log.info("Run Context #{run_context}")
-        @new_resource.source alien_package_debian_source
         alien_log_convert
+        @new_resource.source alien_package_debian_source
       end
     end
   end

--- a/libraries/provider_alien_dpkg.rb
+++ b/libraries/provider_alien_dpkg.rb
@@ -28,8 +28,7 @@ class Chef
 
       def initialize(new_resource, run_context)
         super
-        Chef::Log.info("Run Context #{run_context}")
-        alien_log_convert
+        @new_resource = new_resource
         @new_resource.source alien_package_debian_source
       end
     end

--- a/libraries/provider_alien_dpkg.rb
+++ b/libraries/provider_alien_dpkg.rb
@@ -1,0 +1,37 @@
+# Cookbook Name:: oracle-instantclient
+# Provider:: AlienDpkg
+# Author:: David Kinzer <dtkinzer@gmail.com>
+#
+# Copyright (C) 2014 David Kinzer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'chef/provider/package'
+require 'chef/provider/package/dpkg'
+require_relative 'mixin_alien_converter'
+
+class Chef
+  class Provider
+    # Alien wrapper to the Dpkg package provider.
+    class AlienDpkg < Chef::Provider::Package::Dpkg
+      include Chef::Mixin::AlienConverter
+
+      def initialize(new_resource, run_context)
+        super
+        Chef::Log.info("Run Context #{run_context}")
+        new_resource.source package_debian_source
+        log_convert
+      end
+    end
+  end
+end

--- a/libraries/provider_alien_dpkg.rb
+++ b/libraries/provider_alien_dpkg.rb
@@ -29,8 +29,8 @@ class Chef
       def initialize(new_resource, run_context)
         super
         Chef::Log.info("Run Context #{run_context}")
-        new_resource.source package_debian_source
-        log_convert
+        @new_resource.source alien_package_debian_source
+        alien_log_convert
       end
     end
   end

--- a/libraries/resource_alien_convert.rb
+++ b/libraries/resource_alien_convert.rb
@@ -39,6 +39,11 @@ class Chef
           :kind_of => String
         )
       end
+
+      # This private method is getting called by super.
+      def sentinel_file_if_exists
+        false
+      end
     end
   end
 end

--- a/libraries/resource_alien_convert.rb
+++ b/libraries/resource_alien_convert.rb
@@ -36,7 +36,7 @@ class Chef
         set_or_return(
           :source,
           arg,
-          :king_of => String
+          :kind_of => String
         )
       end
     end

--- a/libraries/resource_alien_convert.rb
+++ b/libraries/resource_alien_convert.rb
@@ -39,11 +39,6 @@ class Chef
           :kind_of => String
         )
       end
-
-      # This private method is getting called by super.
-      def sentinel_file_if_exists
-        false
-      end
     end
   end
 end

--- a/libraries/resource_alien_convert.rb
+++ b/libraries/resource_alien_convert.rb
@@ -1,0 +1,44 @@
+# Cookbook Name:: oracle-instantclient
+# Resource:: alien_convert
+# Author:: David Kinzer <dtkinzer@gmail.com>
+#
+# Copyright (C) 2014 David Kinzer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'chef/resource/execute'
+require_relative 'provider_alien_convert'
+
+class Chef
+  class Resource
+    # Resource definition for alien_convert.
+    class AlienConvert < Chef::Resource::Execute
+      def initialize(name, run_context = nil)
+        super
+        @resource_name = :alien_convert
+        @source = name
+        @action = :convert
+        @allowed_actions.push(:convert)
+        @provider = Chef::Provider::AlienConvert
+      end
+
+      def source(arg = nil)
+        set_or_return(
+          :source,
+          arg,
+          :king_of => String
+        )
+      end
+    end
+  end
+end

--- a/libraries/resource_alien_package.rb
+++ b/libraries/resource_alien_package.rb
@@ -1,0 +1,49 @@
+# Cookbook Name:: oracle-instantclient
+# Resource:: alien_convert
+# Author:: David Kinzer <dtkinzer@gmail.com>
+#
+# Copyright (C) 2014 David Kinzer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'chef/provider/package/yum'
+require_relative 'provider_alien_dpkg'
+
+class Chef
+  class Resource
+    # Resource definition for alien_convert.
+    class AlienPackage < Chef::Resource::Package
+      def initialize(name, run_context = nil)
+        super
+        @resource_name = initial_name
+        @provider = initial_provider
+      end
+
+      def initial_name
+        if platform_family? 'rhel'
+          :yum_package
+        else
+          :alien_package
+        end
+      end
+
+      def initial_provider
+        if platform_family? 'rhel'
+          Chef::Provider::Package::Yum
+        else
+          Chef::Provider::Package::AlienDpkg
+        end
+      end
+    end
+  end
+end

--- a/recipes/alien.rb
+++ b/recipes/alien.rb
@@ -20,7 +20,9 @@
 # @file
 # Install alien package.
 
-package 'alien' do
-  action :install
-  only_if { platform_family? 'debian' }
+node['oracle-instantclient']['debian_packages'].each do |package|
+  package package do
+    action :install
+    only_if { platform_family? 'debian' }
+  end
 end

--- a/recipes/alien.rb
+++ b/recipes/alien.rb
@@ -24,4 +24,3 @@ package 'alien' do
   action :install
   only_if { platform_family? 'debian' }
 end
-

--- a/recipes/alien.rb
+++ b/recipes/alien.rb
@@ -1,0 +1,27 @@
+#
+# Cookbook Name:: oracle-instantclient
+# Recipe:: alien
+# Author:: David Kinzer <dtkinzer@gmail.com>
+#
+# Copyright (C) 2014 David Kinzer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# @file
+# Install alien package.
+
+package 'alien' do
+  action :install
+  only_if { platform_family? 'debian' }
+end
+

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,6 +20,7 @@
 remote_file File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['basic-rpm']) do
   source node['oracle-instantclient']['public-url'] + node['oracle-instantclient']['basic-rpm']
   action :create
+  checksum node['oracle-instantclient']['basic-sha256']
 end
 
 yum_package 'oracle-instantclient12.1-basic' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,7 +23,6 @@ remote_file File.join(Chef::Config[:file_cache_path], node['oracle-instantclient
 end
 
 alien_convert File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['basic-rpm']) do
-  action :install
   only_if { platform_family? 'debian' }
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,6 +22,11 @@ remote_file File.join(Chef::Config[:file_cache_path], node['oracle-instantclient
   checksum node['oracle-instantclient']['basic-sha256']
 end
 
+alien_convert File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['basic-rpm']) do
+  action :install
+  only_if { platform_family? 'debian' }
+end
+
 alien_package 'oracle-instantclient12.1-basic' do
   source File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['basic-rpm'])
   action :install

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,14 +16,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 remote_file File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['basic-rpm']) do
   source node['oracle-instantclient']['public-url'] + node['oracle-instantclient']['basic-rpm']
   action :create
   checksum node['oracle-instantclient']['basic-sha256']
 end
 
-yum_package 'oracle-instantclient12.1-basic' do
+alien_package 'oracle-instantclient12.1-basic' do
   source File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['basic-rpm'])
   action :install
 end

--- a/recipes/sdk.rb
+++ b/recipes/sdk.rb
@@ -21,6 +21,7 @@ include_recipe 'oracle-instantclient'
 
 remote_file File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['sdk-rpm']) do
   source node['oracle-instantclient']['public-url'] + node['oracle-instantclient']['sdk-rpm']
+  checksum node['oracle-instantclient']['sdk-sha256']
   action :create
 end
 

--- a/recipes/sdk.rb
+++ b/recipes/sdk.rb
@@ -25,6 +25,11 @@ remote_file File.join(Chef::Config[:file_cache_path], node['oracle-instantclient
   action :create
 end
 
+alien_convert File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['sdk-rpm']) do
+  action :install
+  only_if { platform_family? 'debian' }
+end
+
 alien_package 'oracle-instantclient12.1-devel' do
   source File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['sdk-rpm'])
   action :install

--- a/recipes/sdk.rb
+++ b/recipes/sdk.rb
@@ -25,7 +25,7 @@ remote_file File.join(Chef::Config[:file_cache_path], node['oracle-instantclient
   action :create
 end
 
-yum_package 'oracle-instantclient12.1-devel' do
+alien_package 'oracle-instantclient12.1-devel' do
   source File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['sdk-rpm'])
   action :install
 end

--- a/recipes/sdk.rb
+++ b/recipes/sdk.rb
@@ -26,7 +26,6 @@ remote_file File.join(Chef::Config[:file_cache_path], node['oracle-instantclient
 end
 
 alien_convert File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['sdk-rpm']) do
-  action :install
   only_if { platform_family? 'debian' }
 end
 

--- a/recipes/sqlplus.rb
+++ b/recipes/sqlplus.rb
@@ -22,6 +22,7 @@ include_recipe 'oracle-instantclient'
 
 remote_file File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['sqlplus-rpm']) do
   source node['oracle-instantclient']['public-url'] + node['oracle-instantclient']['sqlplus-rpm']
+  checksum node['oracle-instantclient']['sqlplus-sha256']
   action :create
 end
 

--- a/recipes/sqlplus.rb
+++ b/recipes/sqlplus.rb
@@ -26,6 +26,11 @@ remote_file File.join(Chef::Config[:file_cache_path], node['oracle-instantclient
   action :create
 end
 
+alien_convert File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['sqlplus-rpm']) do
+  action :install
+  only_if { platform_family? 'debian' }
+end
+
 alien_package 'oracle-instantclient12.1-sqlplus' do
   source File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['sqlplus-rpm'])
   action :install

--- a/recipes/sqlplus.rb
+++ b/recipes/sqlplus.rb
@@ -26,7 +26,7 @@ remote_file File.join(Chef::Config[:file_cache_path], node['oracle-instantclient
   action :create
 end
 
-yum_package 'oracle-instantclient12.1-sqlplus' do
+alien_package 'oracle-instantclient12.1-sqlplus' do
   source File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['sqlplus-rpm'])
   action :install
   notifies :run, 'ruby_block[update-alternatives]', :immediately

--- a/recipes/sqlplus.rb
+++ b/recipes/sqlplus.rb
@@ -27,7 +27,6 @@ remote_file File.join(Chef::Config[:file_cache_path], node['oracle-instantclient
 end
 
 alien_convert File.join(Chef::Config[:file_cache_path], node['oracle-instantclient']['sqlplus-rpm']) do
-  action :install
   only_if { platform_family? 'debian' }
 end
 

--- a/test/libraries/mixin_alien_converter.rb
+++ b/test/libraries/mixin_alien_converter.rb
@@ -25,7 +25,7 @@ require_relative '../../libraries/resource_alien_convert'
 class MockProvider < Chef::Provider
   include Chef::Mixin::AlienConverter
 
-  def shell_out!(command)
+  def shell_out!(command, opts = [])
     command
   end
 end
@@ -50,20 +50,20 @@ class TestAlienConverter < MiniTest::Test
 
   def test_alien_log_convert_not_file_exists
     File.stub :exists?, false do
-      expected = 'alien fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
+      expected = 'cd /foo/bar && alien fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
       actual = @provider.alien_log_convert
       assert_equal expected, actual
     end
   end
 
   def test_alien_convert
-    expected = 'alien fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
+    expected = 'cd /foo/bar && alien fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
     actual = @provider.alien_convert
     assert_equal expected, actual
   end
 
   def test_alien_command
-    expected = 'alien fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
+    expected = 'cd /foo/bar && alien fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
     actual = @provider.alien_command
     assert_equal expected, actual
   end

--- a/test/libraries/mixin_alien_converter.rb
+++ b/test/libraries/mixin_alien_converter.rb
@@ -33,14 +33,15 @@ end
 # Unit tests for Chef::Mixin::AlienConverter.
 class TestAlienConverter < MiniTest::Test
   def setup
-    fake_rpm = '/foo/bar/fake-package-1.2.3.4-0.x86_64.rpm'
+    fake_rpm = '/foo/bar/fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
     resource = Chef::Resource::AlienConvert.new fake_rpm
+    resource.source  '/foo/bar/fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
     @provider = MockProvider.new resource, nil
   end
 
   def test_alien_log_convert_file_exists
     File.stub :exists?, true do
-      message = 'Converted package present - /foo/bar/fake-package_1.2.3.4-0_amd64.deb'
+      message = 'Converted package present - /foo/bar/fake-package12.1-basic_12.2.3.4.5-0_amd64.deb'
       expected = Chef::Log.info(message)
       actual = @provider.alien_log_convert
       assert_equal expected, actual
@@ -49,45 +50,45 @@ class TestAlienConverter < MiniTest::Test
 
   def test_alien_log_convert_not_file_exists
     File.stub :exists?, false do
-      expected = 'alien fake-package-1.2.3.4-0.x86_64.rpm'
+      expected = 'alien fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
       actual = @provider.alien_log_convert
       assert_equal expected, actual
     end
   end
 
   def test_alien_convert
-    expected = 'alien fake-package-1.2.3.4-0.x86_64.rpm'
+    expected = 'alien fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
     actual = @provider.alien_convert
     assert_equal expected, actual
   end
 
   def test_alien_command
-    expected = 'alien fake-package-1.2.3.4-0.x86_64.rpm'
-    actual = @provider.alien_convert
+    expected = 'alien fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
+    actual = @provider.alien_command
     assert_equal expected, actual
   end
 
   def test_alien_package_debian_source
-    expected = '/foo/bar/fake-package_1.2.3.4-0_amd64.deb'
+    expected = '/foo/bar/fake-package12.1-basic_12.2.3.4.5-0_amd64.deb'
     actual = @provider.alien_package_debian_source
     assert_equal expected, actual
   end
 
   def test_alien_package_version
-    expected = '1.2.3.4-0'
+    expected = '12.2.3.4.5-0'
     actual = @provider.alien_package_version
     assert_equal expected, actual
   end
 
-  def test_alien_package_name
-    expected = 'fake-package-1.2.3.4-0.x86_64.rpm'
-    actual = @provider.alien_package_name
+  def test_alien_source_filename
+    expected = 'fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
+    actual = @provider.alien_source_filename
     assert_equal expected, actual
   end
 
-  def test_alien_package_debian_name
-    expected = 'fake-package_1.2.3.4-0_amd64.deb'
-    actual = @provider.alien_package_debian_name
+  def test_alien_package_debian_filename
+    expected = 'fake-package12.1-basic_12.2.3.4.5-0_amd64.deb'
+    actual = @provider.alien_package_debian_filename
     assert_equal expected, actual
   end
 

--- a/test/libraries/mixin_alien_converter.rb
+++ b/test/libraries/mixin_alien_converter.rb
@@ -50,20 +50,20 @@ class TestAlienConverter < MiniTest::Test
 
   def test_alien_log_convert_not_file_exists
     File.stub :exists?, false do
-      expected = 'alien fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
+      expected = 'alien -k fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
       actual = @provider.alien_log_convert
       assert_equal expected, actual
     end
   end
 
   def test_alien_convert
-    expected = 'alien fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
+    expected = 'alien -k fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
     actual = @provider.alien_convert
     assert_equal expected, actual
   end
 
   def test_alien_command
-    expected = 'alien fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
+    expected = 'alien -k fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
     actual = @provider.alien_command
     assert_equal expected, actual
   end

--- a/test/libraries/mixin_alien_converter.rb
+++ b/test/libraries/mixin_alien_converter.rb
@@ -38,62 +38,62 @@ class TestAlienConverter < MiniTest::Test
     @provider = MockProvider.new resource, nil
   end
 
-  def test_log_convert_file_exists
+  def test_alien_log_convert_file_exists
     File.stub :exists?, true do
       message = 'Converted package present - /foo/bar/fake-package_1.2.3.4-0_amd64.deb'
       expected = Chef::Log.info(message)
-      actual = @provider.log_convert
+      actual = @provider.alien_log_convert
       assert_equal expected, actual
     end
   end
 
-  def test_log_convert_not_file_exists
+  def test_alien_log_convert_not_file_exists
     File.stub :exists?, false do
       expected = 'alien fake-package-1.2.3.4-0.x86_64.rpm'
-      actual = @provider.log_convert
+      actual = @provider.alien_log_convert
       assert_equal expected, actual
     end
   end
 
-  def test_convert
+  def test_alien_convert
     expected = 'alien fake-package-1.2.3.4-0.x86_64.rpm'
-    actual = @provider.convert
+    actual = @provider.alien_convert
     assert_equal expected, actual
   end
 
-  def test_command
+  def test_alien_command
     expected = 'alien fake-package-1.2.3.4-0.x86_64.rpm'
-    actual = @provider.convert
+    actual = @provider.alien_convert
     assert_equal expected, actual
   end
 
-  def test_package_debian_source
+  def test_alien_package_debian_source
     expected = '/foo/bar/fake-package_1.2.3.4-0_amd64.deb'
-    actual = @provider.package_debian_source
+    actual = @provider.alien_package_debian_source
     assert_equal expected, actual
   end
 
-  def test_package_version
+  def test_alien_package_version
     expected = '1.2.3.4-0'
-    actual = @provider.package_version
+    actual = @provider.alien_package_version
     assert_equal expected, actual
   end
 
-  def test_package_name
+  def test_alien_package_name
     expected = 'fake-package-1.2.3.4-0.x86_64.rpm'
-    actual = @provider.package_name
+    actual = @provider.alien_package_name
     assert_equal expected, actual
   end
 
-  def test_package_debian_name
+  def test_alien_package_debian_name
     expected = 'fake-package_1.2.3.4-0_amd64.deb'
-    actual = @provider.package_debian_name
+    actual = @provider.alien_package_debian_name
     assert_equal expected, actual
   end
 
-  def test_package_directory
+  def test_alien_package_directory
     expected = '/foo/bar'
-    actual = @provider.package_directory
+    actual = @provider.alien_package_directory
     assert_equal expected, actual
   end
 end

--- a/test/libraries/mixin_alien_converter.rb
+++ b/test/libraries/mixin_alien_converter.rb
@@ -50,20 +50,20 @@ class TestAlienConverter < MiniTest::Test
 
   def test_alien_log_convert_not_file_exists
     File.stub :exists?, false do
-      expected = 'cd /foo/bar && alien fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
+      expected = 'alien fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
       actual = @provider.alien_log_convert
       assert_equal expected, actual
     end
   end
 
   def test_alien_convert
-    expected = 'cd /foo/bar && alien fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
+    expected = 'alien fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
     actual = @provider.alien_convert
     assert_equal expected, actual
   end
 
   def test_alien_command
-    expected = 'cd /foo/bar && alien fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
+    expected = 'alien fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
     actual = @provider.alien_command
     assert_equal expected, actual
   end

--- a/test/libraries/mixin_alien_converter.rb
+++ b/test/libraries/mixin_alien_converter.rb
@@ -1,0 +1,99 @@
+# Cookbook Name:: oracle-instantclient
+# Mixin:: alien_converter
+# Author:: David Kinzer <dtkinzer@gmail.com>
+#
+# Copyright (C) 2014 David Kinzer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'minitest/autorun'
+require 'minitest/mock'
+require_relative '../../libraries/mixin_alien_converter'
+require_relative '../../libraries/resource_alien_convert'
+
+# Allow tests to run in a mock provider.
+class MockProvider < Chef::Provider
+  include Chef::Mixin::AlienConverter
+
+  def shell_out!(command)
+    command
+  end
+end
+
+# Unit tests for Chef::Mixin::AlienConverter.
+class TestAlienConverter < MiniTest::Test
+  def setup
+    fake_rpm = '/foo/bar/fake-package-1.2.3.4-0.x86_64.rpm'
+    resource = Chef::Resource::AlienConvert.new fake_rpm
+    @provider = MockProvider.new resource, nil
+  end
+
+  def test_log_convert_file_exists
+    File.stub :exists?, true do
+      message = 'Converted package present - /foo/bar/fake-package_1.2.3.4-0_amd64.deb'
+      expected = Chef::Log.info(message)
+      actual = @provider.log_convert
+      assert_equal expected, actual
+    end
+  end
+
+  def test_log_convert_not_file_exists
+    File.stub :exists?, false do
+      expected = 'alien fake-package-1.2.3.4-0.x86_64.rpm'
+      actual = @provider.log_convert
+      assert_equal expected, actual
+    end
+  end
+
+  def test_convert
+    expected = 'alien fake-package-1.2.3.4-0.x86_64.rpm'
+    actual = @provider.convert
+    assert_equal expected, actual
+  end
+
+  def test_command
+    expected = 'alien fake-package-1.2.3.4-0.x86_64.rpm'
+    actual = @provider.convert
+    assert_equal expected, actual
+  end
+
+  def test_package_debian_source
+    expected = '/foo/bar/fake-package_1.2.3.4-0_amd64.deb'
+    actual = @provider.package_debian_source
+    assert_equal expected, actual
+  end
+
+  def test_package_version
+    expected = '1.2.3.4-0'
+    actual = @provider.package_version
+    assert_equal expected, actual
+  end
+
+  def test_package_name
+    expected = 'fake-package-1.2.3.4-0.x86_64.rpm'
+    actual = @provider.package_name
+    assert_equal expected, actual
+  end
+
+  def test_package_debian_name
+    expected = 'fake-package_1.2.3.4-0_amd64.deb'
+    actual = @provider.package_debian_name
+    assert_equal expected, actual
+  end
+
+  def test_package_directory
+    expected = '/foo/bar'
+    actual = @provider.package_directory
+    assert_equal expected, actual
+  end
+end

--- a/test/libraries/provider_alien_convert.rb
+++ b/test/libraries/provider_alien_convert.rb
@@ -58,8 +58,16 @@ class TestProviderAlienConvert < MiniTest::Test
   end
 
   def test_action_convert
-    expected = Chef::Log.info('Alien conversion successful.')
-    actual = @provider.action_convert
-    assert_equal expected, actual
+    File.stub :exists?, false do
+      expected = Chef::Log.info('Alien conversion successful.')
+      actual = @provider.action_convert
+      assert_equal expected, actual
+    end
+  end
+
+  def test_action_convert_already_converted
+    File.stub :exists?, true do
+      refute @provider.action_convert, 'Do not re-convert.'
+    end
   end
 end

--- a/test/libraries/provider_alien_convert.rb
+++ b/test/libraries/provider_alien_convert.rb
@@ -1,0 +1,65 @@
+# Cookbook Name:: oracle-instantclient
+# Provider:: alien_converter
+# Author:: David Kinzer <dtkinzer@gmail.com>
+#
+# Copyright (C) 2014 David Kinzer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'minitest/autorun'
+require_relative '../../libraries/resource_alien_convert'
+require_relative '../../libraries/provider_alien_convert'
+
+# Override the shell_out method.
+class Chef::Provider::AlienConvert
+  def shell_out!(command, options = [])
+    command
+  end
+
+  def converge_by(description, &block)
+    instance_eval(&block)
+  end
+end
+
+# Unit tests for Chef::Provider::AlienConvert
+class TestProviderAlienConvert < MiniTest::Test
+  def setup
+    fake_rpm = '/foo/bar/fake-package-1.2.3.4-0.x86_64.rpm'
+    resource = Chef::Resource::AlienConvert.new fake_rpm
+    @provider = Chef::Provider::AlienConvert.new resource, nil
+  end
+
+  def test_cwd_initialization
+    expected = '/foo/bar'
+    actual = @provider.new_resource.cwd
+    assert_equal expected, actual
+  end
+
+  def test_command_initialization
+    expected = 'alien fake-package-1.2.3.4-0.x86_64.rpm'
+    actual = @provider.new_resource.command
+    assert_equal expected, actual
+  end
+
+  def test_creates_initialization
+    expected = '/foo/bar/fake-package_1.2.3.4-0_amd64.deb'
+    actual = @provider.new_resource.creates
+    assert_equal expected, actual
+  end
+
+  def test_action_convert
+    expected = Chef::Log.info('Alien conversion successful.')
+    actual = @provider.action_convert
+    assert_equal expected, actual
+  end
+end

--- a/test/libraries/provider_alien_convert.rb
+++ b/test/libraries/provider_alien_convert.rb
@@ -22,7 +22,7 @@ require_relative '../../libraries/provider_alien_convert'
 
 # Override the shell_out method.
 class Chef::Provider::AlienConvert
-  def shell_out!(command, options = [])
+  def shell_out!(command, opts = [])
     command
   end
 
@@ -46,7 +46,7 @@ class TestProviderAlienConvert < MiniTest::Test
   end
 
   def test_command_initialization
-    expected = 'alien fake-package-1.2.3.4-0.x86_64.rpm'
+    expected = 'cd /foo/bar && alien fake-package-1.2.3.4-0.x86_64.rpm'
     actual = @provider.new_resource.command
     assert_equal expected, actual
   end

--- a/test/libraries/provider_alien_convert.rb
+++ b/test/libraries/provider_alien_convert.rb
@@ -46,7 +46,7 @@ class TestProviderAlienConvert < MiniTest::Test
   end
 
   def test_command_initialization
-    expected = 'alien fake-package-1.2.3.4-0.x86_64.rpm'
+    expected = 'alien -k fake-package-1.2.3.4-0.x86_64.rpm'
     actual = @provider.new_resource.command
     assert_equal expected, actual
   end

--- a/test/libraries/provider_alien_convert.rb
+++ b/test/libraries/provider_alien_convert.rb
@@ -46,7 +46,7 @@ class TestProviderAlienConvert < MiniTest::Test
   end
 
   def test_command_initialization
-    expected = 'cd /foo/bar && alien fake-package-1.2.3.4-0.x86_64.rpm'
+    expected = 'alien fake-package-1.2.3.4-0.x86_64.rpm'
     actual = @provider.new_resource.command
     assert_equal expected, actual
   end

--- a/test/libraries/provider_alien_dpkg.rb
+++ b/test/libraries/provider_alien_dpkg.rb
@@ -1,0 +1,43 @@
+# Cookbook Name:: oracle-instantclient
+# Provider:: AlienDpkg
+# Author:: David Kinzer <dtkinzer@gmail.com>
+#
+# Copyright (C) 2014 David Kinzer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'minitest/autorun'
+require 'chef/resource/dpkg_package'
+require_relative '../../libraries/provider_alien_dpkg'
+
+# Override the shell_out method.
+class Chef::Provider::AlienDpkg
+  def shell_out!(command, options = [])
+    command
+  end
+end
+
+# Unit tests for Chef::Provider::AlienConvert
+class TestProviderAlienDpkg < MiniTest::Test
+  def setup
+    resource = Chef::Resource::DpkgPackage.new 'A-fake-rpm-package'
+    resource.source '/foo/bar/fake-package-1.2.3.4-0.x86_64.rpm'
+    @provider = Chef::Provider::AlienDpkg.new resource, nil
+  end
+
+  def test_source_initialization
+    expected = '/foo/bar/fake-package_1.2.3.4-0_amd64.deb'
+    actual = @provider.new_resource.source
+    assert_equal expected, actual
+  end
+end

--- a/test/libraries/provider_alien_dpkg.rb
+++ b/test/libraries/provider_alien_dpkg.rb
@@ -16,13 +16,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# Override the shell_out method.
+#
 require 'minitest/autorun'
 require 'chef/resource/dpkg_package'
 require_relative '../../libraries/provider_alien_dpkg'
 
-# Override the shell_out method.
+# Override shell_out method.
 class Chef::Provider::AlienDpkg
-  def shell_out!(command, options = [])
+  def shell_out!(command, opts = [])
     command
   end
 end
@@ -30,13 +32,13 @@ end
 # Unit tests for Chef::Provider::AlienConvert
 class TestProviderAlienDpkg < MiniTest::Test
   def setup
-    resource = Chef::Resource::DpkgPackage.new 'A-fake-rpm-package'
-    resource.source '/foo/bar/fake-package-1.2.3.4-0.x86_64.rpm'
-    @provider = Chef::Provider::AlienDpkg.new resource, nil
+    new_resource = Chef::Resource::DpkgPackage.new 'A-fake-rpm-package'
+    new_resource.source '/foo/bar/fake-package12.1-basic-12.2.3.4.5-0.x86_64.rpm'
+    @provider = Chef::Provider::AlienDpkg.new new_resource, nil
   end
 
   def test_source_initialization
-    expected = '/foo/bar/fake-package_1.2.3.4-0_amd64.deb'
+    expected = '/foo/bar/fake-package12.1-basic_12.2.3.4.5-0_amd64.deb'
     actual = @provider.new_resource.source
     assert_equal expected, actual
   end

--- a/test/libraries/resource_alien_convert.rb
+++ b/test/libraries/resource_alien_convert.rb
@@ -21,7 +21,7 @@ require_relative '../../libraries/resource_alien_convert'
 
 # Override the shell_out method.
 class Chef::Resource::AlienConvert
-  def shell_out!(command, options = [])
+  def shell_out!(command, opts = [])
     command
   end
 

--- a/test/libraries/resource_alien_convert.rb
+++ b/test/libraries/resource_alien_convert.rb
@@ -1,5 +1,5 @@
 # Cookbook Name:: oracle-instantclient
-# Resource:: alien_converter
+# Resource:: alien_convert
 # Author:: David Kinzer <dtkinzer@gmail.com>
 #
 # Copyright (C) 2014 David Kinzer
@@ -30,7 +30,7 @@ class Chef::Resource::AlienConvert
   end
 end
 
-# Unit tests for Chef::Provider::AlienConvert
+# Unit tests for Chef::Resource::AlienConvert
 class TestResourceAlienConvert < MiniTest::Test
   def setup
     fake_rpm = '/foo/bar/fake-package-1.2.3.4-0.x86_64.rpm'
@@ -55,6 +55,13 @@ class TestResourceAlienConvert < MiniTest::Test
 
   def test_source_initialization
     expected = '/foo/bar/fake-package-1.2.3.4-0.x86_64.rpm'
+    actual = @resource.source
+    assert_equal expected, actual
+  end
+
+  def test_can_set_source
+    @resource.source 'foo'
+    expected = 'foo'
     actual = @resource.source
     assert_equal expected, actual
   end

--- a/test/libraries/resource_alien_convert.rb
+++ b/test/libraries/resource_alien_convert.rb
@@ -1,0 +1,61 @@
+# Cookbook Name:: oracle-instantclient
+# Resource:: alien_converter
+# Author:: David Kinzer <dtkinzer@gmail.com>
+#
+# Copyright (C) 2014 David Kinzer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'minitest/autorun'
+require_relative '../../libraries/resource_alien_convert'
+
+# Override the shell_out method.
+class Chef::Resource::AlienConvert
+  def shell_out!(command, options = [])
+    command
+  end
+
+  def converge_by(description, &block)
+    instance_eval(&block)
+  end
+end
+
+# Unit tests for Chef::Provider::AlienConvert
+class TestResourceAlienConvert < MiniTest::Test
+  def setup
+    fake_rpm = '/foo/bar/fake-package-1.2.3.4-0.x86_64.rpm'
+    @resource = Chef::Resource::AlienConvert.new fake_rpm
+  end
+
+  def test_action_initialization
+    expected = :convert
+    actual = @resource.action
+    assert_equal expected, actual
+  end
+
+  def test_allowed_actions_initialization
+    assert @resource.allowed_actions.include?(:convert)
+  end
+
+  def test_provider_initialization
+    expected = Chef::Provider::AlienConvert
+    actual = @resource.provider
+    assert_equal expected, actual
+  end
+
+  def test_source_initialization
+    expected = '/foo/bar/fake-package-1.2.3.4-0.x86_64.rpm'
+    actual = @resource.source
+    assert_equal expected, actual
+  end
+end

--- a/test/libraries/resource_alien_package.rb
+++ b/test/libraries/resource_alien_package.rb
@@ -1,0 +1,58 @@
+# Cookbook Name:: oracle-instantclient
+# Resource:: alien_package
+# Author:: David Kinzer <dtkinzer@gmail.com>
+#
+# Copyright (C) 2014 David Kinzer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'minitest/autorun'
+require 'chef/dsl/platform_introspection'
+require_relative '../../libraries/resource_alien_package'
+
+# Override platform_family?
+class Chef::Resource::AlienPackage
+  def platform_family?(family)
+    true
+  end
+end
+
+# Unit test Chef::Resource::AlienPackage.
+class TestResourceAlienPackage < MiniTest::Test
+  def setup
+    fake_rpm = '/foo/bar/fake-package-1.2.3.4-0.x86_64.rpm'
+    @resource = Chef::Resource::AlienPackage.new fake_rpm
+  end
+
+  def test_init_when_rhel
+    expected = Chef::Provider::Package::Yum
+    actual = @resource.initial_provider
+    assert_equal  expected, actual, 'The correct provider is set.'
+
+    expected = :yum_package
+    actual = @resource.initial_name
+    assert_equal expected, actual, 'The correct resource name is set.'
+  end
+
+  def test_init_when_debian
+    @resource.stub :platform_family?, false do
+      expected = Chef::Provider::Package::AlienDpkg
+      actual = @resource.initial_provider
+      assert_equal  expected, actual, 'The correct provider is set.'
+
+      expected = :alien_package
+      actual = @resource.initial_name
+      assert_equal expected, actual, 'The correct resource name is set.'
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds Ubuntu 14.04 support for this cookbook. (I've only tested
the 64 bit version and only the php recipe.)

The main components of the pull request are two new resources and their
providers:
1. alien_convert: Takes the rpm package and converts it to debian.
2. alien_package: A factory type resource that behaves like the yum_package
   resource on relh family platforms or like a dpkg_package resource on debian
   platforms.
3. There is also an alien mixin module that I use to share some functionality
   between alien_convert and alien_package resources.

At this point I have include both the alien_convert and the alien_package in
each of the recipes, however, my intention is to come back at some point in
the future and insert the alient_convert resource as a step in the alien_package
resource (I couldn't figure out how to do this in time to meet a deadline I
have).
