### PR TITLE
Execute ldconfig immediately

### DIFF
--- a/recipes/sqlplus.rb
+++ b/recipes/sqlplus.rb
@@ -47,7 +47,7 @@ template '/etc/ld.so.conf.d/oracle-instantclient-86_64.conf' do
       :version => node['oracle-instantclient']['version'],
       :client_arch => client_arch
   )
-  notifies :run, 'execute[ldconfig]'
+  notifies :run, 'execute[ldconfig]', :immediate
 end
 
 ruby_block 'update-alternatives' do


### PR DESCRIPTION
sqlplus fails to execute if run during same converge

```
sqlplus64: error while loading shared libraries: libsqlplus.so: cannot open shared object file: No such file or directory
```

ldconfig should be run immediately.
